### PR TITLE
Jwt bug

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
 	"github.com/swaggo/gin-swagger"
@@ -43,7 +42,7 @@ func InitRouter() *gin.Engine {
 	authMiddleware, err := middleware.AuthInit()
 
 	if err != nil {
-		_ = fmt.Errorf("JWT Error", err.Error())
+		log.Fatalln("JWT Error", err.Error())
 	}
 
 	r.POST("/login", authMiddleware.LoginHandler)


### PR DESCRIPTION
当middleware.AuthInit()返回错误时，authMiddleware为nil，我认为应该直接退出程序
`log.Fatalln("JWT Error", err.Error())`
而原处理只是生成一个错误
`fmt.Errorf`
此时程序将会向下执行，执行到
`authMiddleware.LoginHandler`将会panic，因为authMiddleware为nil。