### PR TITLE
fix: Use NewSyncedEnforcer instead NewEnforcer

### DIFF
--- a/global/adm.go
+++ b/global/adm.go
@@ -8,7 +8,7 @@ import (
 )
 
 var GinEngine *gin.Engine
-var CasbinEnforcer *casbin.Enforcer
+var CasbinEnforcer *casbin.SyncedEnforcer
 var Eloquent *gorm.DB
 
 var (

--- a/pkg/casbin/mycasbin.go
+++ b/pkg/casbin/mycasbin.go
@@ -33,14 +33,14 @@ func Setup() {
 	if err != nil {
 		panic(err)
 	}
-	e, err := casbin.NewEnforcer(m, Apter)
+	e, err := casbin.NewSyncedEnforcer(m, Apter)
 	if err != nil {
 		panic(err)
 	}
 	global.CasbinEnforcer = e
 }
 
-func Casbin() (*casbin.Enforcer, error) {
+func Casbin() (*casbin.SyncedEnforcer, error) {
 	if err := global.CasbinEnforcer.LoadPolicy(); err == nil {
 		return global.CasbinEnforcer, err
 	} else {


### PR DESCRIPTION
## Summary

Use NewEnforcer instead of NewSyncedEnforcer, because NewEnforcer is not thread safe, so catch #180 and #180, Casbin provides a thread safe enforcer is SyncedEnforcer, It can fix the above issues.

issues: #180, #181 

